### PR TITLE
set olcSecurity after olcLocalSSF

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,9 +7,8 @@ default_global_config:
   olcPidFile: "{{ slapd_run_dir | mandatory }}/slapd.pid"
   olcGentleHUP: "FALSE"
   olcServerID: 0
-  # Security-related configuration
+  # Security-related configuration (except olcSecurity; see below)
   olcRequires: "bind"
-  olcSecurity: "ssf=1 simple_bind=128"
   olcAuthzPolicy: "none"
   olcLocalSSF: 300
   olcPasswordHash: "{SSHA}"
@@ -39,6 +38,10 @@ default_global_config:
   # Miscellaneous
   olcReverseLookup: "FALSE"
   olcReadOnly: "FALSE"
+  # olcSecurity needs to come after `olcLocalSSF: 300`. Otherwise, the
+  # simple_bind=128 requirement causes a failure with an error message
+  # of "stronger confidentiality required"
+  olcSecurity: "ssf=1 simple_bind=128"
 # Frontend database configuration
 default_frontend_config:
   # General


### PR DESCRIPTION
`olcSecurity` needs to come after `olcLocalSSF: 300`. Otherwise, the `simple_bind=128`
requirement causes a failure with an error message of "stronger confidentiality required".

Our conjecture is that this used to work because an older python and/or ansible
version iterated through the dict keys in a different order, so the `olcLocalSSF`
configuration change was applied before the `olcSecurity` change.